### PR TITLE
Fix TrainAE inference, warmup-only mode, and CI Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,10 +22,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Docker image for Python ${{ matrix.python-version }}
         run: |
@@ -139,17 +139,17 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Docker image for Python ${{ matrix.python-version }}
         run: |
           docker build -t bernn:py${{ matrix.python-version }} --build-arg PYTHON_VERSION=${{ matrix.python-version }} .
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends r-base r-base-dev
+          sudo apt-get install -y --no-install-recommends r-base r-base-dev libtirpc-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends r-base r-base-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install -e ".[full]"
           pip install pytest pytest-cov
       - name: Run tests with coverage
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,16 @@ RUN if [ "$PYTHON_VERSION" = "3.11" ]; then \
         python3.12 get-pip.py && \
         python3.12 -m pip install --upgrade pip setuptools wheel && \
         rm get-pip.py; \
+    elif [ "$PYTHON_VERSION" = "3.13" ]; then \
+        add-apt-repository ppa:deadsnakes/ppa && \
+        apt-get update && \
+        apt-get install -y --no-install-recommends python3.13 python3.13-dev python3.13-venv && \
+        ln -sf /usr/bin/python3.13 /usr/bin/python && \
+        ln -sf /usr/bin/python3.13 /usr/bin/python3 && \
+        curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+        python3.13 get-pip.py && \
+        python3.13 -m pip install --upgrade pip setuptools wheel && \
+        rm get-pip.py; \
     else \
         apt-get update && \
         apt-get install -y --no-install-recommends python3 python3-dev python3-distutils && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.1.1-runtime-ubuntu20.04
+FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
 
 # Build argument for Python version
 ARG PYTHON_VERSION=3.11
@@ -26,8 +26,7 @@ RUN apt-get update && \
         r-base-dev \
         r-cran-devtools \
         python3-dev \
-        software-properties-common \
-        linux-modules-nvidia-525-generic && \
+        software-properties-common && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
     rm -rf /var/lib/apt/lists/*
@@ -36,7 +35,7 @@ RUN apt-get update && \
 RUN if [ "$PYTHON_VERSION" = "3.11" ]; then \
         add-apt-repository ppa:deadsnakes/ppa && \
         apt-get update && \
-        apt-get install -y --no-install-recommends python3.11 python3.11-dev python3.11-distutils && \
+        apt-get install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv && \
         ln -sf /usr/bin/python3.11 /usr/bin/python && \
         ln -sf /usr/bin/python3.11 /usr/bin/python3 && \
         curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
@@ -46,7 +45,7 @@ RUN if [ "$PYTHON_VERSION" = "3.11" ]; then \
     elif [ "$PYTHON_VERSION" = "3.12" ]; then \
         add-apt-repository ppa:deadsnakes/ppa && \
         apt-get update && \
-        apt-get install -y --no-install-recommends python3.12 python3.12-dev && \
+        apt-get install -y --no-install-recommends python3.12 python3.12-dev python3.12-venv && \
         ln -sf /usr/bin/python3.12 /usr/bin/python && \
         ln -sf /usr/bin/python3.12 /usr/bin/python3 && \
         curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \

--- a/README.md
+++ b/README.md
@@ -41,6 +41,44 @@ Important runtime contract:
 - groups_train is mandatory.
 - If X_test is provided, groups_test is mandatory.
 
+## Inference and transformed inputs
+
+After `fit(...)` or `fit_predict(...)`, the trainer restores the best validation
+model before inference. If filesystem logging is enabled, the same model is also
+saved as `best_model.pth` under the run log directory and its path is available as
+`trainer.best_checkpoint_path`.
+
+```python
+# Predicted labels
+preds = trainer.infer(X_test)
+
+# Predicted labels plus bottleneck, reconstruction, and probabilities
+outputs = trainer.infer(X_test, return_representations=True)
+encoded = outputs["encoded"]
+reconstructed = outputs["reconstructed"]
+probabilities = outputs.get("probabilities")
+
+# Direct getters
+encoded = trainer.get_encoded_inputs(X_test)
+reconstructed = trainer.get_reconstructed_inputs(X_test)
+```
+
+## Train only the warmup phase
+
+Use `train_only_warmup=True` when you only want to train the autoencoder warmup
+phase and skip the supervised/classifier training epochs.
+
+```python
+trainer = TrainAE(
+    train_only_warmup=True,
+    warmup=100,
+    n_epochs=100,
+    log_mlflow=False,
+)
+trainer.fit(X_train, y_train, groups_train=batches_train)
+encoded = trainer.get_encoded_inputs(X_train)
+```
+
 ## Important parameters
 
 Focus on these first:
@@ -52,6 +90,7 @@ Focus on these first:
 - n_layers, layer1: classifier depth and width seed.
 - dloss: domain loss mode.
 - warmup, n_epochs: core training schedule.
+- train_only_warmup: run only the autoencoder warmup phase.
 - device: cpu/cuda target.
 - scaler, bs: preprocessing and batch size.
 

--- a/bernn/dl/train/train_ae.py
+++ b/bernn/dl/train/train_ae.py
@@ -155,6 +155,7 @@ class TrainAE:
         self.load_tb = load_tb
         self.groupkfold = groupkfold
         self.foldername = None
+        self.complete_log_path = None
         self.verbose = 1
         self.n_cats = None
         self.data = None
@@ -562,6 +563,8 @@ class TrainAE:
         while response == -1:
             self._prepare_data(X=X_train, y=y_train, groups=groups_train, X_test=X_test, y_test=y_test, groups_test=groups_test, cross_validation=cross_validation, cross_test=cross_test, val_size=val_size)
             response = self._train(params)
+        if self.best_state_dicts is not None:
+            self.restore_best_model_state()
         if X_test is not None:
             return self.predict(X_test)
         else:
@@ -588,6 +591,7 @@ class TrainAE:
         
         if is_best:
             self.best_mcc = valid_mcc
+            self._save_best_model_state(epoch, valid_mcc)
             
             # Create checkpoint directory if it doesn't exist
             if self.complete_log_path:
@@ -712,6 +716,11 @@ class TrainAE:
                 self.ae.train()
                 self.warmup_loop(optimizer_ae, None, self.ae, celoss, loaders['all'], triplet_loss, mseloss, True, warmup_epoch, values, loggers, {}, traces, None)
 
+        if getattr(self.args, 'train_only_warmup', False):
+            self._save_best_model_state(max(warmup_epochs - 1, 0), self.best_mcc if self.best_mcc > -1 else 0.0)
+            print("Warmup-only training requested; skipping supervised training epochs.")
+            return self
+
         pbar = tqdm(range(warmup_epochs, n_epochs), desc="Epochs", unit="epoch")
         for epoch in pbar:
             lists, traces = get_empty_traces()
@@ -759,38 +768,93 @@ class TrainAE:
         print("Training completed.")
         return self
 
+    def _as_inference_frame(self, X):
+        if isinstance(X, pd.DataFrame):
+            return X
+        return pd.DataFrame(X)
+
+    def _inference_loader(self, X):
+        from torch.utils.data import DataLoader, TensorDataset
+
+        X = self._as_inference_frame(X)
+        dataset = TensorDataset(torch.tensor(X.values, dtype=torch.float32))
+        return DataLoader(dataset, batch_size=getattr(self.args, 'bs', 32), shuffle=False)
+
+    def _default_inference_batches(self, n_rows, device):
+        return torch.zeros(n_rows, dtype=torch.long, device=device)
+
+    @staticmethod
+    def _extract_reconstruction(reconstruction):
+        if isinstance(reconstruction, dict):
+            reconstruction = reconstruction.get('mean', reconstruction)
+        if isinstance(reconstruction, (list, tuple)):
+            reconstruction = reconstruction[-1]
+        return reconstruction
+
+    def _forward_representations(self, X, return_reconstruction=False):
+        if not isinstance(self.ae, nn.Module):
+            raise ValueError("AutoEncoder is not initialized. Please run training first.")
+
+        self.ae.eval()
+        device = getattr(self.args, 'device', 'cpu')
+        encoded_list = []
+        reconstructed_list = []
+
+        with torch.no_grad():
+            for batch in self._inference_loader(X):
+                data = batch[0].to(device)
+                domain = self._default_inference_batches(data.shape[0], device)
+                output = self.ae(data, data.clone(), domain, sampling=False)
+                enc = output[0]
+                encoded_list.append(enc.detach().cpu().numpy())
+
+                if return_reconstruction:
+                    rec = self._extract_reconstruction(output[1])
+                    reconstructed_list.append(rec.detach().cpu().numpy())
+
+        encoded = np.concatenate(encoded_list, axis=0)
+        if not return_reconstruction:
+            return encoded
+        reconstructed = np.concatenate(reconstructed_list, axis=0)
+        return encoded, reconstructed
+
     def transform(self, X):
         """
         Transform X into the latent space of the autoencoder.
         """
-        if not isinstance(self.ae, nn.Module):
-            raise ValueError("AutoEncoder is not initialized. Please run training first.")
-        
-        self.ae.enc.eval()
-        self.ae.classifier.eval()
-        
-        if not isinstance(X, pd.DataFrame):
-            X = pd.DataFrame(X)
-        
-        # We need a dataloader to transform X
-        from torch.utils.data import DataLoader, TensorDataset
-        dataset = TensorDataset(torch.tensor(X.values, dtype=torch.float32))
-        loader = DataLoader(dataset, batch_size=getattr(self.args, 'bs', 32), shuffle=False)
-        
-        from tqdm import tqdm
-        encoded_list = []
-        with torch.no_grad():
-            for batch in tqdm(loader, desc="Transforming", leave=False):
-                data = batch[0].to(self.args.device)
-                
-                # Mock domain as all zeros
-                domain = torch.zeros(data.shape[0], dtype=torch.long, device=self.args.device)
-                to_rec = data.clone()
-                
-                enc, _, _, _ = self.ae(data, to_rec, domain, sampling=False)
-                encoded_list.append(enc.detach().cpu().numpy())
-                
-        return np.concatenate(encoded_list, axis=0)
+        return self.get_encoded_inputs(X)
+
+    def get_encoded_inputs(self, X):
+        """Return bottleneck/latent representations for X."""
+        return self._forward_representations(X, return_reconstruction=False)
+
+    def get_reconstructed_inputs(self, X):
+        """Return autoencoder reconstructions for X."""
+        _, reconstructed = self._forward_representations(X, return_reconstruction=True)
+        return reconstructed
+
+    def infer(self, X, return_representations=False):
+        """Run inference with the trained best model.
+
+        By default this returns predicted labels, matching ``predict``. Set
+        ``return_representations=True`` to also return bottleneck encodings,
+        reconstructions, and probabilities when available.
+        """
+        predictions = self.predict(X)
+        if not return_representations:
+            return predictions
+
+        encoded, reconstructed = self._forward_representations(X, return_reconstruction=True)
+        result = {
+            'predictions': predictions,
+            'encoded': encoded,
+            'reconstructed': reconstructed,
+        }
+        try:
+            result['probabilities'] = self.predict_proba(X)
+        except Exception:
+            pass
+        return result
 
     def predict(self, X):
         """
@@ -893,6 +957,7 @@ class TrainAE:
             'early_stop': 50,
             'early_warmup_stop': -1,
             'train_after_warmup': 0,
+            'train_only_warmup': 0,
             'threshold': 0.,
             'n_epochs': 1000,
             'n_trials': 100,

--- a/tests/unit/test_train_ae_helpers.py
+++ b/tests/unit/test_train_ae_helpers.py
@@ -1,6 +1,7 @@
 """Unit tests for TrainAE helpers in bernn/dl/train/train_ae.py."""
 import pytest
 import numpy as np
+import torch
 from types import SimpleNamespace
 
 from bernn.dl.train.train_ae import TrainAE
@@ -14,6 +15,7 @@ def _minimal_args(**overrides):
         early_stop=5,
         early_warmup_stop=-1,
         train_after_warmup=0,
+        train_only_warmup=0,
         threshold=0.0,
         n_epochs=1,
         rec_loss="l1",
@@ -231,3 +233,63 @@ def test_binarize_labels_produces_binary(tmp_path):
     assert set(result["labels"]["all"]).issubset({0, 1})
     assert result["labels"]["all"][0] == 0   # ctrl → 0
     assert result["labels"]["all"][1] == 1   # case → 1
+
+
+class _TinyAE(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.enc = torch.nn.Linear(2, 2)
+        self.dec = torch.nn.Linear(2, 2)
+        self.classifier = torch.nn.Linear(2, 2)
+
+    def forward(self, x, to_rec, batches=None, sampling=False, **kwargs):
+        encoded = self.enc(x)
+        reconstructed = {"mean": self.dec(encoded)}
+        return [encoded, reconstructed, torch.zeros(1)]
+
+    def predict(self, x):
+        return self.classifier(self.enc(x)).argmax(1).detach().cpu().numpy()
+
+    def predict_proba(self, x):
+        return torch.softmax(self.classifier(self.enc(x)), dim=1).detach().cpu().numpy()
+
+
+@pytest.fixture
+def inference_trainer(trainer):
+    trainer.ae = _TinyAE()
+    trainer.args.device = "cpu"
+    trainer.args.bs = 2
+    return trainer
+
+
+@pytest.mark.unit
+def test_get_encoded_inputs_returns_bottleneck(inference_trainer):
+    X = np.ones((3, 2), dtype=np.float32)
+    encoded = inference_trainer.get_encoded_inputs(X)
+    assert encoded.shape == (3, 2)
+
+
+@pytest.mark.unit
+def test_get_reconstructed_inputs_returns_original_feature_shape(inference_trainer):
+    X = np.ones((3, 2), dtype=np.float32)
+    reconstructed = inference_trainer.get_reconstructed_inputs(X)
+    assert reconstructed.shape == (3, 2)
+
+
+@pytest.mark.unit
+def test_infer_can_return_predictions_and_representations(inference_trainer):
+    X = np.ones((3, 2), dtype=np.float32)
+    result = inference_trainer.infer(X, return_representations=True)
+    assert set(["predictions", "encoded", "reconstructed", "probabilities"]).issubset(result)
+    assert result["predictions"].shape == (3,)
+    assert result["encoded"].shape == (3, 2)
+    assert result["reconstructed"].shape == (3, 2)
+    assert result["probabilities"].shape == (3, 2)
+
+
+@pytest.mark.unit
+def test_validate_and_save_best_checkpoint_keeps_in_memory_state(inference_trainer, tmp_path):
+    inference_trainer.complete_log_path = str(tmp_path)
+    assert inference_trainer._validate_and_save_best_checkpoint(inference_trainer.ae, epoch=4, valid_mcc=0.25)
+    assert inference_trainer.best_state_dicts is not None
+    assert inference_trainer.best_epoch == 4


### PR DESCRIPTION
## Summary\n- add TrainAE infer(), get_encoded_inputs(), and get_reconstructed_inputs() APIs\n- persist best model state in memory when validation improves, so fit()/fit_predict() restore the best model consistently\n- add train_only_warmup to skip supervised epochs after autoencoder warmup\n- document best checkpoint access, inference outputs, encoded/reconstructed getters, and warmup-only training\n- fix Docker Python 3.13 installation and refresh Docker workflow action versions\n\n## Validation\n- python3 -m py_compile bernn/dl/train/train_ae.py tests/unit/test_train_ae_helpers.py\n- git diff --check\n\nFull pytest was not run locally because this environment is missing pytest, torch, sklearn, and mlflow. GitHub Actions should run the full matrix on this PR.\n\nCloses #2\nCloses #3\nCloses #4\nCloses #5\nCloses #6